### PR TITLE
sliding footer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,9 @@
+html,
+body {
+    height: 100%;
+    margin: 0;
+}
+
+.page-content {
+    flex-grow: 1;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -16,8 +16,8 @@ function App() {
   };
 
   return (
-    <Container fluid>
-      <Container fluid>
+    <Container fluid className="d-flex flex-column min-vh-100 p-0">
+      <Container className="page-content p-0">
         <Row>
           <Col>
             <Header />


### PR DESCRIPTION
Ensure that the footer sticks to the bottom of the viewport when there is enough space, and otherwise, it will appear below the content. Closes #5 