### PR TITLE
Add dark mode styling (with theme toggle)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,23 @@
 html,
 body {
-    height: 100%;
-    margin: 0;
+  height: 100%;
+  margin: 0;
 }
 
 .page-content {
-    flex-grow: 1;
+  flex-grow: 1;
+}
+
+.dark,
+.dark .card,
+.dark .table {
+  background-color: #333;
+  color: #fff;
+  border-color: white;
+}
+.light,
+.light .card {
+  background-color: #fff;
+  color: #333;
+  border-color: black;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container, Row, Col } from "react-bootstrap";
+import { Container, Row, Col, Form } from "react-bootstrap";
 import { defaultInputs, UserMenu } from "./components/UserMenu";
 import TaxBreakdown from "./components/TaxBreakdown";
 import PensionAnalysis from "./components/PensionAnalysis";
@@ -44,6 +44,14 @@ function App() {
         <Row>
           <Col>
             <Header theme={theme} themeToggleFunction={toggleTheme} />
+            <Form.Check
+              type="switch"
+              id="themeToggle"
+              label="Dark mode"
+              name="themeToggle"
+              checked={theme === "dark"}
+              onChange={toggleTheme}
+            />
             <UserMenu onUserInputsChange={handleUserInputsChange} />
             {userInputs.incomeAnalysis && (
               <PensionAnalysis inputs={userInputs} plotThemer={setPlotTheme} />

--- a/src/App.js
+++ b/src/App.js
@@ -1,41 +1,61 @@
-import React from 'react';
-import { Container, Row, Col } from 'react-bootstrap';
-import { defaultInputs, UserMenu } from './components/UserMenu';
-import TaxBreakdown from './components/TaxBreakdown';
-import PensionAnalysis from './components/PensionAnalysis';
-import TaxYearOverview from './components/TaxYearOverview';
-import Header from './components/Header';
-import Footer from './components/Footer';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import React from "react";
+import { Container, Row, Col } from "react-bootstrap";
+import { defaultInputs, UserMenu } from "./components/UserMenu";
+import TaxBreakdown from "./components/TaxBreakdown";
+import PensionAnalysis from "./components/PensionAnalysis";
+import TaxYearOverview from "./components/TaxYearOverview";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import "bootstrap/dist/css/bootstrap.min.css";
 
 function App() {
   const [userInputs, setUserInputs] = React.useState(defaultInputs);
+  const [theme, setTheme] = React.useState("dark");
+
+  React.useEffect(() => {
+    document.body.className = theme;
+  }, [theme]);
 
   const handleUserInputsChange = (inputs) => {
     setUserInputs(inputs);
   };
+
+  function toggleTheme() {
+    if (theme === "light") {
+      setTheme("dark");
+    } else {
+      setTheme("light");
+    }
+  }
+
+  // takes plotly theme data as JSON and adds dark theme if necessary
+  function setPlotTheme(layout) {
+    if (theme === "dark") {
+      layout.paper_bgcolor = "#333";
+      layout.plot_bgcolor = "#222";
+      layout.font = { color: "#fff" };
+    }
+    return layout;
+  }
 
   return (
     <Container fluid className="d-flex flex-column min-vh-100 p-0">
       <Container className="page-content p-0">
         <Row>
           <Col>
-            <Header />
+            <Header theme={theme} themeToggleFunction={toggleTheme} />
             <UserMenu onUserInputsChange={handleUserInputsChange} />
-            {
-              userInputs.incomeAnalysis &&
-              <PensionAnalysis inputs={userInputs} />
-            }
+            {userInputs.incomeAnalysis && (
+              <PensionAnalysis inputs={userInputs} plotThemer={setPlotTheme} />
+            )}
           </Col>
           <Col>
-            {
-              userInputs.incomeAnalysis &&
-              <TaxBreakdown inputs={userInputs} />
-            }
-            {
-              !userInputs.incomeAnalysis &&
-              <TaxYearOverview inputs={userInputs} />
-            }
+            {userInputs.incomeAnalysis && (
+              <TaxBreakdown inputs={userInputs} theme={theme} />
+            )}
+            {!userInputs.incomeAnalysis && (
+              <TaxYearOverview inputs={userInputs} plotThemer={setPlotTheme} />
+            )}
           </Col>
           {/* <Col>
           </Col> */}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navbar, Container, Form } from "react-bootstrap";
+import { Navbar, Container } from "react-bootstrap";
 
 const Header = (props) => {
   return (

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,15 +10,9 @@ const Header = (props) => {
             <strong>
               Cool<span className="text-danger">Tax</span>Tool
             </strong>
-            {/* <button onClick={props.themeToggleFunction}>Current theme:</button> */}
-            <Form.Check
-              type="switch"
-              id="themeToggle"
-              label="Dark mode"
-              name="themeToggle"
-              checked={props.theme === "dark"}
-              onChange={props.themeToggleFunction}
-            />
+            {/* <button onClick={props.themeToggleFunction}>
+              Toggle dark mode
+            </button> */}
           </h1>
         </Navbar.Brand>
       </Container>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,20 +1,29 @@
-import React from 'react';
-import { Navbar, Container } from 'react-bootstrap';
+import React from "react";
+import { Navbar, Container, Form } from "react-bootstrap";
 
-const Header = () => {
-    return (
-        <Navbar>
-            <Container className="justify-content-center large">
-                <Navbar.Brand>
-                    <h1>
-                        <strong>
-                            Cool<span className="text-danger">Tax</span>Tool
-                        </strong>
-                    </h1>
-                </Navbar.Brand>
-            </Container>
-        </Navbar>
-    );
+const Header = (props) => {
+  return (
+    <Navbar>
+      <Container className="justify-content-center large">
+        <Navbar.Brand>
+          <h1>
+            <strong>
+              Cool<span className="text-danger">Tax</span>Tool
+            </strong>
+            {/* <button onClick={props.themeToggleFunction}>Current theme:</button> */}
+            <Form.Check
+              type="switch"
+              id="themeToggle"
+              label="Dark mode"
+              name="themeToggle"
+              checked={props.theme === "dark"}
+              onChange={props.themeToggleFunction}
+            />
+          </h1>
+        </Navbar.Brand>
+      </Container>
+    </Navbar>
+  );
 };
 
 export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,9 +10,6 @@ const Header = (props) => {
             <strong>
               Cool<span className="text-danger">Tax</span>Tool
             </strong>
-            {/* <button onClick={props.themeToggleFunction}>
-              Toggle dark mode
-            </button> */}
           </h1>
         </Navbar.Brand>
       </Container>

--- a/src/components/PensionAnalysis.js
+++ b/src/components/PensionAnalysis.js
@@ -1,37 +1,58 @@
-import React, { useState, useEffect } from 'react';
-import Plot from 'react-plotly.js';
-import { Container } from 'react-bootstrap';
-import { calculateTaxes } from '../utils/TaxCalc';
+import React, { useState, useEffect } from "react";
+import Plot from "react-plotly.js";
+import { Container } from "react-bootstrap";
+import { calculateTaxes } from "../utils/TaxCalc";
 
-const TaxSavingsVsPensionContributions = ({ inputs }) => {
+const TaxSavingsVsPensionContributions = (props) => {
   const [taxSavingsPlotData, setTaxSavingsPlotData] = useState([]);
 
   useEffect(() => {
-    const pensionContributions = Array.from({ length: 1000 }, (_, i) => i * inputs.grossIncome / 1000);
+    const pensionContributions = Array.from(
+      { length: 1000 },
+      (_, i) => (i * props.inputs.grossIncome) / 1000
+    );
 
     const taxSavingsData = pensionContributions.map((pensionContribution) => {
       const inputsWithVoluntaryPension = {
-        ...inputs,
+        ...props.inputs,
         pensionContributions: {
-          ...inputs.pensionContributions,
+          ...props.inputs.pensionContributions,
           personal: pensionContribution,
         },
       };
 
       const inputsWithoutVoluntaryPension = {
-        ...inputs,
+        ...props.inputs,
         pensionContributions: {
-          ...inputs.pensionContributions,
+          ...props.inputs.pensionContributions,
           personal: 0,
         },
       };
 
-      const taxesWithVoluntaryPension = calculateTaxes(inputs.grossIncome, inputsWithVoluntaryPension);
-      const taxesWithoutVoluntaryPension = calculateTaxes(inputs.grossIncome, inputsWithoutVoluntaryPension);
+      const taxesWithVoluntaryPension = calculateTaxes(
+        props.inputs.grossIncome,
+        inputsWithVoluntaryPension
+      );
+      const taxesWithoutVoluntaryPension = calculateTaxes(
+        props.inputs.grossIncome,
+        inputsWithoutVoluntaryPension
+      );
 
-      const taxSavings = taxesWithoutVoluntaryPension.combinedTaxes - taxesWithVoluntaryPension.combinedTaxes;
-      const taxSavingsPercentage = Math.max(0, Math.min(100, (taxSavings / pensionContribution) * 100));
-      const effectiveTaxRate = Math.max(0, Math.min(100, (taxesWithVoluntaryPension.combinedTaxes / inputs.grossIncome) * 100));
+      const taxSavings =
+        taxesWithoutVoluntaryPension.combinedTaxes -
+        taxesWithVoluntaryPension.combinedTaxes;
+      const taxSavingsPercentage = Math.max(
+        0,
+        Math.min(100, (taxSavings / pensionContribution) * 100)
+      );
+      const effectiveTaxRate = Math.max(
+        0,
+        Math.min(
+          100,
+          (taxesWithVoluntaryPension.combinedTaxes / props.inputs.grossIncome) *
+            100
+        )
+      );
 
       return { pensionContribution, taxSavingsPercentage, effectiveTaxRate };
     });
@@ -39,36 +60,36 @@ const TaxSavingsVsPensionContributions = ({ inputs }) => {
     const taxSavingsPlot = {
       x: taxSavingsData.map((data) => data.pensionContribution),
       y: taxSavingsData.map((data) => data.taxSavingsPercentage),
-      type: 'scatter',
-      mode: 'lines',
-      marker: { color: '#2ecc71' },
-      name: 'Tax Savings (%)',
-      hovertemplate: '%{y:.1f}%',
+      type: "scatter",
+      mode: "lines",
+      marker: { color: "#2ecc71" },
+      name: "Tax Savings (%)",
+      hovertemplate: "%{y:.1f}%",
     };
 
     const effectiveTaxRatePlot = {
       x: taxSavingsData.map((data) => data.pensionContribution),
       y: taxSavingsData.map((data) => data.effectiveTaxRate),
-      type: 'scatter',
-      mode: 'lines',
-      marker: { color: '#3498db' },
-      name: 'Effective Tax Rate (%)',
-      hovertemplate: '%{y:.1f}%',
+      type: "scatter",
+      mode: "lines",
+      marker: { color: "#3498db" },
+      name: "Effective Tax Rate (%)",
+      hovertemplate: "%{y:.1f}%",
     };
 
     setTaxSavingsPlotData([taxSavingsPlot, effectiveTaxRatePlot]);
-  }, [inputs]);
+  }, [props.inputs]);
 
   return (
     <Container fluid>
       <Plot
         data={taxSavingsPlotData}
-        layout={{
-          hovermode: 'x',
-          title: 'Tax Savings and Effective Tax Rate vs Pension Contributions',
-          xaxis: { title: 'Pension Contributions (£)' },
-          yaxis: { title: 'Percentage (%)' },
-        }}
+        layout={props.plotThemer({
+          hovermode: "x",
+          title: "Tax Savings and Effective Tax Rate vs Pension Contributions",
+          xaxis: { title: "Pension Contributions (£)" },
+          yaxis: { title: "Percentage (%)" },
+        })}
       />
     </Container>
   );

--- a/src/components/TaxBreakdown.js
+++ b/src/components/TaxBreakdown.js
@@ -1,102 +1,128 @@
-import React from 'react';
-import { calculateTaxes } from '../utils/TaxCalc';
-import { Container, Table, Card } from 'react-bootstrap';
-import { numberWithCommas } from '../utils/DisplayFormat';
+import React from "react";
+import { calculateTaxes } from "../utils/TaxCalc";
+import { Container, Table, Card } from "react-bootstrap";
+import { numberWithCommas } from "../utils/DisplayFormat";
 
-const TaxBreakdown = ({ inputs }) => {
-    const results = calculateTaxes(inputs.grossIncome, inputs);
+const TaxBreakdown = (props) => {
+  const results = calculateTaxes(props.inputs.grossIncome, props.inputs);
 
-    function renderBreakDown(breakdown) {
-        return breakdown.map((tax, i) => (
-            <tr key={`it-${i}`}>
-                <td className="small" style={{ paddingLeft: '2em' }}>{`${isNaN(tax.rate) ? tax.rate : ((tax.rate * 100).toFixed(2) + '%')}`}</td>
-                <td className="text-end small">{numberWithCommas(tax.amount)}</td>
-            </tr>
-        ));
-    }
+  function renderBreakDown(breakdown) {
+    return breakdown.map((tax, i) => (
+      <tr key={`it-${i}`}>
+        <td className="small" style={{ paddingLeft: "2em" }}>{`${
+          isNaN(tax.rate) ? tax.rate : (tax.rate * 100).toFixed(2) + "%"
+        }`}</td>
+        <td className="text-end small">{numberWithCommas(tax.amount)}</td>
+      </tr>
+    ));
+  }
 
-    return (
-        <Container>
-            <Card>
-                <Card.Body>
-                    <Card.Title>Tax breakdown for {numberWithCommas(inputs.grossIncome)}</Card.Title>
+  return (
+    <Container>
+      <Card>
+        <Card.Body>
+          <Card.Title>
+            Tax breakdown for {numberWithCommas(props.inputs.grossIncome)}
+          </Card.Title>
 
-                    <Table size="sm">
-                        <tbody>
-                            <tr>
-                                <td>Gross Income</td>
-                                <td className="text-end">{numberWithCommas(results.grossIncome)}</td>
-                            </tr>
-                            <tr>
-                                <td>Adjusted Net Income</td>
-                                <td className="text-end">{numberWithCommas(results.adjustedNetIncome)}</td>
-                            </tr>
-                            <tr>
-                                <td>Personal Allowance</td>
-                                <td className="text-end">{numberWithCommas(results.personalAllowance)}</td>
-                            </tr>
-                            <tr>
-                                <td>Employer NI</td>
-                                <td className="text-end">{numberWithCommas(results.employerNI.total)}</td>
-                            </tr>
-                            {renderBreakDown(results.employerNI.breakdown)}
-                        </tbody>
-                    </Table>
+          <Table size="sm">
+            <tbody>
+              <tr>
+                <td>Gross Income</td>
+                <td className="text-end">
+                  {numberWithCommas(results.grossIncome)}
+                </td>
+              </tr>
+              <tr>
+                <td>Adjusted Net Income</td>
+                <td className="text-end">
+                  {numberWithCommas(results.adjustedNetIncome)}
+                </td>
+              </tr>
+              <tr>
+                <td>Personal Allowance</td>
+                <td className="text-end">
+                  {numberWithCommas(results.personalAllowance)}
+                </td>
+              </tr>
+              <tr>
+                <td>Employer NI</td>
+                <td className="text-end">
+                  {numberWithCommas(results.employerNI.total)}
+                </td>
+              </tr>
+              {renderBreakDown(results.employerNI.breakdown)}
+            </tbody>
+          </Table>
 
-                    <Table size="sm" variant="danger">
-                        <thead>
-                            <tr>
-                                <th>You pay</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>Income Tax</td>
-                                <td className="text-end">{numberWithCommas(results.incomeTax.total)}</td>
-                            </tr>
-                            {renderBreakDown(results.incomeTax.breakdown)}
-                            <tr>
-                                <td>Employee NI</td>
-                                <td className="text-end">{numberWithCommas(results.employeeNI.total)}</td>
-                            </tr>
-                            {renderBreakDown(results.employeeNI.breakdown)}
-                            <tr>
-                                <td>Student Loan</td>
-                                <td className="text-end">{numberWithCommas(results.studentLoanRepayments)}</td>
-                            </tr>
-                            <tr>
-                                <td>Total</td>
-                                <td className="text-end">{numberWithCommas(results.combinedTaxes)}</td>
-                            </tr>
-                        </tbody>
-                    </Table>
+          <Table size="sm" variant="danger" style={{ color: "#000" }}>
+            <thead>
+              <tr>
+                <th>You pay</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Income Tax</td>
+                <td className="text-end">
+                  {numberWithCommas(results.incomeTax.total)}
+                </td>
+              </tr>
+              {renderBreakDown(results.incomeTax.breakdown)}
+              <tr>
+                <td>Employee NI</td>
+                <td className="text-end">
+                  {numberWithCommas(results.employeeNI.total)}
+                </td>
+              </tr>
+              {renderBreakDown(results.employeeNI.breakdown)}
+              <tr>
+                <td>Student Loan</td>
+                <td className="text-end">
+                  {numberWithCommas(results.studentLoanRepayments)}
+                </td>
+              </tr>
+              <tr>
+                <td>Total</td>
+                <td className="text-end">
+                  {numberWithCommas(results.combinedTaxes)}
+                </td>
+              </tr>
+            </tbody>
+          </Table>
 
-                    <Table size="sm" variant="success">
-                        <thead>
-                            <tr>
-                                <th>You keep</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>Take Home Pay</td>
-                                <td className="text-end">{numberWithCommas(results.takeHomePay)}</td>
-                            </tr>
-                            <tr>
-                                <td>Pension Pot</td>
-                                <td className="text-end">{numberWithCommas(results.pensionPot.total)}</td>
-                            </tr>
-                            {renderBreakDown(results.pensionPot.breakdown)}
-                            <tr>
-                                <td>Total</td>
-                                <td className="text-end">{numberWithCommas(results.yourMoney)}</td>
-                            </tr>
-                        </tbody>
-                    </Table>
-                </Card.Body>
-            </Card>
-        </Container>
-    );
+          <Table size="sm" variant="success" style={{ color: "#000" }}>
+            <thead>
+              <tr>
+                <th>You keep</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Take Home Pay</td>
+                <td className="text-end">
+                  {numberWithCommas(results.takeHomePay)}
+                </td>
+              </tr>
+              <tr>
+                <td>Pension Pot</td>
+                <td className="text-end">
+                  {numberWithCommas(results.pensionPot.total)}
+                </td>
+              </tr>
+              {renderBreakDown(results.pensionPot.breakdown)}
+              <tr>
+                <td>Total</td>
+                <td className="text-end">
+                  {numberWithCommas(results.yourMoney)}
+                </td>
+              </tr>
+            </tbody>
+          </Table>
+        </Card.Body>
+      </Card>
+    </Container>
+  );
 };
 
 export default TaxBreakdown;

--- a/src/components/TaxYearOverview.js
+++ b/src/components/TaxYearOverview.js
@@ -1,87 +1,113 @@
-import React, { useState, useEffect } from 'react';
-import Plot from 'react-plotly.js';
-import { Container } from 'react-bootstrap';
-import { calculateTaxes } from '../utils/TaxCalc';
+import React, { useState, useEffect } from "react";
+import Plot from "react-plotly.js";
+import { Container } from "react-bootstrap";
+import { calculateTaxes } from "../utils/TaxCalc";
 
 const plotSettings = [
-  { key: 'adjustedNetIncome', color: '#3498db', label: 'Adjusted Net Income' },
-  { key: 'personalAllowance', color: '#1abc9c', label: 'Personal Allowance' },
-  { key: 'taxableIncome', color: '#2980b9', label: 'Taxable Income' },
-  { key: 'incomeTax', color: '#8e44ad', label: 'Income Tax' },
-  { key: 'employeeNI', color: '#e74c3c', label: 'Employee NI Contributions' },
-  { key: 'employerNI', color: '#d35400', label: 'Employer NI Contributions' },
-  { key: 'studentLoanRepayments', color: '#f39c12', label: 'Student Loan Repayments' },
-  { key: 'combinedTaxes', color: '#c0392b', label: 'Combined taxes (IT, EE NI, SL)' },
-  { key: 'takeHomePay', color: '#2ecc71', label: 'Take Home Pay' },
-  { key: 'pensionPot', color: '#27ae60', label: 'Pension Pot' },
-  { key: 'yourMoney', color: '#16a085', label: 'Your money (Pension Pot + Take Home)' },
-  { key: 'marginalCombinedTaxRate', color: '#f1c40f', label: 'Marginal Combined Tax Rate', dashed: true },
+  { key: "adjustedNetIncome", color: "#3498db", label: "Adjusted Net Income" },
+  { key: "personalAllowance", color: "#1abc9c", label: "Personal Allowance" },
+  { key: "taxableIncome", color: "#2980b9", label: "Taxable Income" },
+  { key: "incomeTax", color: "#8e44ad", label: "Income Tax" },
+  { key: "employeeNI", color: "#e74c3c", label: "Employee NI Contributions" },
+  { key: "employerNI", color: "#d35400", label: "Employer NI Contributions" },
+  {
+    key: "studentLoanRepayments",
+    color: "#f39c12",
+    label: "Student Loan Repayments",
+  },
+  {
+    key: "combinedTaxes",
+    color: "#c0392b",
+    label: "Combined taxes (IT, EE NI, SL)",
+  },
+  { key: "takeHomePay", color: "#2ecc71", label: "Take Home Pay" },
+  { key: "pensionPot", color: "#27ae60", label: "Pension Pot" },
+  {
+    key: "yourMoney",
+    color: "#16a085",
+    label: "Your money (Pension Pot + Take Home)",
+  },
+  {
+    key: "marginalCombinedTaxRate",
+    color: "#f1c40f",
+    label: "Marginal Combined Tax Rate",
+    dashed: true,
+  },
 ];
 
-const TaxYearOverview = ({ inputs }) => {
+const TaxYearOverview = (props) => {
   const [percentagePlotData, setPercentagePlotData] = useState([]);
   const [amountPlotData, setAmountPlotData] = useState([]);
 
   useEffect(() => {
-    const grossIncomes = Array.from({ length: 1000 }, (_, i) => i * inputs.salaryRange / 1000);
+    const grossIncomes = Array.from(
+      { length: 1000 },
+      (_, i) => (i * props.inputs.salaryRange) / 1000
+    );
 
     const taxData = grossIncomes.map((grossIncome) => {
-      const { incomeTax, employeeNI, employerNI, pensionPot, ...rest } = calculateTaxes(grossIncome, inputs);
+      const { incomeTax, employeeNI, employerNI, pensionPot, ...rest } =
+        calculateTaxes(grossIncome, props.inputs);
       return {
         incomeTax: incomeTax.total,
         employeeNI: employeeNI.total,
         employerNI: employerNI.total,
         pensionPot: pensionPot.total,
-        ...rest
+        ...rest,
       };
     });
 
     const marginalCombinedTaxes = [];
     for (let i = 1; i < taxData.length; i++) {
-      const deltaTaxes = taxData[i].combinedTaxes - taxData[i - 1].combinedTaxes;
+      const deltaTaxes =
+        taxData[i].combinedTaxes - taxData[i - 1].combinedTaxes;
       const deltaIncome = grossIncomes[i] - grossIncomes[i - 1];
       marginalCombinedTaxes.push((deltaTaxes / deltaIncome) * 100);
     }
 
     const createPlotData = (grossIncomes, dataArray, isPercentage = false) => {
-      return plotSettings.map((setting) => {
-        if (
-          ((setting.key === 'employeeNI' || setting.key === 'employerNI') && inputs.noNI) ||
-          (setting.key === 'studentLoanRepayments' && inputs.studentLoan === 'none') ||
-          (setting.key === 'personalAllowance' && isPercentage) ||
-          (setting.key === 'marginalCombinedTaxRate' && !isPercentage)
-        ) {
-          return null;
-        }
+      return plotSettings
+        .map((setting) => {
+          if (
+            ((setting.key === "employeeNI" || setting.key === "employerNI") &&
+              props.inputs.noNI) ||
+            (setting.key === "studentLoanRepayments" &&
+              props.inputs.studentLoan === "none") ||
+            (setting.key === "personalAllowance" && isPercentage) ||
+            (setting.key === "marginalCombinedTaxRate" && !isPercentage)
+          ) {
+            return null;
+          }
 
-        const hoverTemplate = isPercentage
-          ? '%{y:.1f}%'
-          : '£%{y:,.2f}';
+          const hoverTemplate = isPercentage ? "%{y:.1f}%" : "£%{y:,.2f}";
 
-        if (setting.key === 'marginalCombinedTaxRate' && isPercentage) {
+          if (setting.key === "marginalCombinedTaxRate" && isPercentage) {
+            return {
+              x: grossIncomes.slice(1),
+              y: marginalCombinedTaxes,
+              type: "scatter",
+              mode: "lines",
+              line: { dash: "dash", color: setting.color },
+              name: setting.label,
+              hovertemplate: hoverTemplate,
+            };
+          }
           return {
-            x: grossIncomes.slice(1),
-            y: marginalCombinedTaxes,
-            type: 'scatter',
-            mode: 'lines',
-            line: { dash: 'dash', color: setting.color },
+            x: grossIncomes,
+            y: dataArray.map((data) => {
+              const value = isPercentage
+                ? (data[setting.key] / data["grossIncome"]) * 100
+                : data[setting.key];
+              return isPercentage ? Math.max(0, Math.min(100, value)) : value;
+            }),
+            type: "scatter",
+            mode: "lines",
+            marker: { color: setting.color },
             name: setting.label,
             hovertemplate: hoverTemplate,
           };
-        }
-        return {
-          x: grossIncomes,
-          y: dataArray.map((data) => {
-            const value = isPercentage ? (data[setting.key] / data['grossIncome']) * 100 : data[setting.key];
-            return isPercentage ? Math.max(0, Math.min(100, value)) : value;
-          }),
-          type: 'scatter',
-          mode: 'lines',
-          marker: { color: setting.color },
-          name: setting.label,
-          hovertemplate: hoverTemplate,
-        };
-      }).filter((data) => data !== null);
+        })
+        .filter((data) => data !== null);
     };
 
     const amountPlotData = createPlotData(grossIncomes, taxData);
@@ -89,28 +115,28 @@ const TaxYearOverview = ({ inputs }) => {
 
     setPercentagePlotData(percentagePlotData);
     setAmountPlotData(amountPlotData);
-  }, [inputs]);
+  }, [props.inputs]);
 
   return (
     <Container fluid>
       <Plot
         data={percentagePlotData}
-        layout={{
-          hovermode: 'x',
-          title: 'Percentages of gross income',
-          xaxis: { title: 'Annual Gross Income (£)' },
-          yaxis: { title: 'Percentage of Income (%)' },
-        }}
+        layout={props.plotThemer({
+          hovermode: "x",
+          title: "Percentages of gross income",
+          xaxis: { title: "Annual Gross Income (£)" },
+          yaxis: { title: "Percentage of Income (%)" },
+        })}
       />
 
       <Plot
         data={amountPlotData}
-        layout={{
-          hovermode: 'x',
-          title: 'Annual total amounts',
-          xaxis: { title: 'Annual Gross Income (£)' },
-          yaxis: { title: 'Annual Total Amount (£)' },
-        }}
+        layout={props.plotThemer({
+          hovermode: "x",
+          title: "Annual total amounts",
+          xaxis: { title: "Annual Gross Income (£)" },
+          yaxis: { title: "Annual Total Amount (£)" },
+        })}
       />
     </Container>
   );


### PR DESCRIPTION
This PR adds dark mode to the application, controlled by a theme toggle under the header. Closes #1 

Toggle, under header:

![image](https://user-images.githubusercontent.com/51709667/235330009-c5ca0a14-dde6-4d5e-83de-3a416c700d34.png)

Light mode:

![image](https://user-images.githubusercontent.com/51709667/235329950-21d4e303-4cfa-45c8-98a7-45076a77ee5b.png)

![image](https://user-images.githubusercontent.com/51709667/235329960-431f3a01-6e0f-4672-8768-c0577ff71de8.png)

Dark mode:

![image](https://user-images.githubusercontent.com/51709667/235329966-09fc5e14-f76b-429f-96d6-166bb2a44e75.png)

![image](https://user-images.githubusercontent.com/51709667/235329973-7e23b0de-00fc-4993-a369-3ad1d0e370bc.png)


Notes:
- default theme on page load is dark mode
- plot themer function can be used to theme any new plots which are added later on