### PR TITLE
Student loans hotfix

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,9 +8,9 @@ const Header = (props) => {
         <Navbar.Brand>
           <h1>
             <strong>
-            <span className="text-primary">Cool</span>
-            <span className="text-danger">Tax</span>
-            <span className="text-primary">Tool</span>
+              <span className="text-primary">Cool</span>
+              <span className="text-danger">Tax</span>
+              <span className="text-primary">Tool</span>
             </strong>
           </h1>
         </Navbar.Brand>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,18 +1,23 @@
 import React from "react";
-import { Navbar, Container } from "react-bootstrap";
+import { Navbar, Container, Row } from "react-bootstrap";
 
-const Header = (props) => {
+const Header = () => {
   return (
     <Navbar>
       <Container className="justify-content-center large">
         <Navbar.Brand>
-          <h1>
-            <strong>
-              <span className="text-primary">Cool</span>
-              <span className="text-danger">Tax</span>
-              <span className="text-primary">Tool</span>
-            </strong>
-          </h1>
+          <Row>
+            <h1>
+              <strong>
+                <span className="text-primary">Cool</span>
+                <span className="text-danger">Tax</span>
+                <span className="text-primary">Tool</span>
+              </strong>
+            </h1>
+          </Row>
+          <Row className="text-primary">
+            UK Tax Calculator & Visualiser
+          </Row>
         </Navbar.Brand>
       </Container>
     </Navbar>

--- a/src/components/IncomeAnalysis/PensionAnalysis.js
+++ b/src/components/IncomeAnalysis/PensionAnalysis.js
@@ -1,14 +1,18 @@
 import React, { useState, useEffect } from "react";
 import Plot from "react-plotly.js";
-import { calculateTaxes } from "../../utils/TaxCalc";
+import { calculateAnnualGrossIncome, calculateTaxes } from "../../utils/TaxCalc";
 
 const TaxSavingsVsPensionContributions = (props) => {
   const [taxSavingsPlotData, setTaxSavingsPlotData] = useState([]);
 
   useEffect(() => {
+    const annualGrossIncome = calculateAnnualGrossIncome(
+      props.inputs.annualGrossSalary, props.inputs.annualGrossBonus
+    ).total;
+
     const pensionContributions = Array.from(
       { length: 1000 },
-      (_, i) => (i * props.inputs.grossIncome) / 1000
+      (_, i) => (i * annualGrossIncome) / 1000
     );
 
     const taxSavingsData = pensionContributions.map((pensionContribution) => {
@@ -28,14 +32,9 @@ const TaxSavingsVsPensionContributions = (props) => {
         },
       };
 
-      const taxesWithVoluntaryPension = calculateTaxes(
-        props.inputs.grossIncome,
-        inputsWithVoluntaryPension
-      );
-      const taxesWithoutVoluntaryPension = calculateTaxes(
-        props.inputs.grossIncome,
-        inputsWithoutVoluntaryPension
-      );
+      const taxesWithVoluntaryPension = calculateTaxes(inputsWithVoluntaryPension);
+      const taxesWithoutVoluntaryPension = calculateTaxes(inputsWithoutVoluntaryPension);
+
 
       const taxSavings =
         taxesWithoutVoluntaryPension.combinedTaxes -
@@ -48,8 +47,7 @@ const TaxSavingsVsPensionContributions = (props) => {
         0,
         Math.min(
           100,
-          (taxesWithVoluntaryPension.combinedTaxes / props.inputs.grossIncome) *
-          100
+          (taxesWithVoluntaryPension.combinedTaxes / annualGrossIncome) * 100
         )
       );
 

--- a/src/components/IncomeAnalysis/PensionAnalysis.js
+++ b/src/components/IncomeAnalysis/PensionAnalysis.js
@@ -49,7 +49,7 @@ const TaxSavingsVsPensionContributions = (props) => {
         Math.min(
           100,
           (taxesWithVoluntaryPension.combinedTaxes / props.inputs.grossIncome) *
-            100
+          100
         )
       );
 
@@ -80,15 +80,15 @@ const TaxSavingsVsPensionContributions = (props) => {
   }, [props.inputs]);
 
   return (
-      <Plot
-        data={taxSavingsPlotData}
-        layout={props.plotThemer({
-          hovermode: "x",
-          title: "Tax Savings and Effective Tax Rate vs Pension Contributions",
-          xaxis: { title: "Pension Contributions (£)" },
-          yaxis: { title: "Percentage (%)" },
-        })}
-      />
+    <Plot
+      data={taxSavingsPlotData}
+      layout={props.plotThemer({
+        hovermode: "x",
+        title: "Tax Savings and Effective Tax Rate vs Pension Contributions",
+        xaxis: { title: "Pension Contributions (£)" },
+        yaxis: { title: "Percentage (%)" },
+      })}
+    />
   );
 };
 

--- a/src/components/IncomeAnalysis/TaxBreakdown.js
+++ b/src/components/IncomeAnalysis/TaxBreakdown.js
@@ -4,7 +4,7 @@ import { Table, Card } from "react-bootstrap";
 import { numberWithCommas } from "../../utils/DisplayFormat";
 
 const TaxBreakdown = (props) => {
-  const results = calculateTaxes(props.inputs.grossIncome, props.inputs);
+  const results = calculateTaxes(props.inputs);
 
   function renderSingleValue(name, value) {
     return (
@@ -36,14 +36,14 @@ const TaxBreakdown = (props) => {
     <Card>
       <Card.Body>
         <Card.Title>
-          Tax breakdown for {numberWithCommas(props.inputs.grossIncome)}
+          Tax breakdown
         </Card.Title>
 
         <Table size="sm">
           <tbody>
-            {renderSingleValue("Gross Income", results.grossIncome)}
+            {renderBreakDown("Annual Gross Income", results.annualGrossIncome)}
             {renderSingleValue("Adjusted Net Income", results.adjustedNetIncome)}
-            {renderSingleValue("Tax Allowance", results.taxAllowance)}
+            {renderBreakDown("Tax Allowance", results.taxAllowance)}
             {renderBreakDown("Employer NI", results.employerNI)}
           </tbody>
         </Table>

--- a/src/components/TaxYearOverview.js
+++ b/src/components/TaxYearOverview.js
@@ -94,7 +94,8 @@ const TaxYearOverview = (props) => {
               return isPercentage ? Math.max(0, Math.min(100, value)) : value;
             }),
             type: "scatter",
-            line: { dash: setting.dashed ? "dash" : "line" },
+            mode: "lines",
+            line: { dash: setting.dashed ? "dash" : "solid" },
             marker: { color: setting.color },
             name: setting.label,
             hovertemplate: hoverTemplate,

--- a/src/components/TaxYearOverview.js
+++ b/src/components/TaxYearOverview.js
@@ -94,7 +94,7 @@ const TaxYearOverview = (props) => {
               return isPercentage ? Math.max(0, Math.min(100, value)) : value;
             }),
             type: "scatter",
-            line: { dash: setting.dashed ? "dash" : "line"},
+            line: { dash: setting.dashed ? "dash" : "line" },
             marker: { color: setting.color },
             name: setting.label,
             hovertemplate: hoverTemplate,

--- a/src/components/TaxYearOverview.js
+++ b/src/components/TaxYearOverview.js
@@ -75,7 +75,7 @@ const TaxYearOverview = (props) => {
             ((setting.key === "employeeNI" || setting.key === "employerNI") &&
               props.inputs.noNI) ||
             (setting.key === "studentLoanRepayments" &&
-              props.inputs.studentLoan === []) ||
+              props.inputs.studentLoan.length === 0) ||
             (setting.key === "taxAllowance" && isPercentage) ||
             (setting.key === "marginalCombinedTaxRate" && !isPercentage) ||
             (setting.key === "childBenefits" && !props.inputs.childBenefits.childBenefitsTaken)

--- a/src/components/TaxYearOverview.js
+++ b/src/components/TaxYearOverview.js
@@ -41,16 +41,17 @@ const TaxYearOverview = (props) => {
   const [amountPlotData, setAmountPlotData] = useState([]);
 
   useEffect(() => {
-    const targetAnnualGrossIncomes = Array.from(
+    const grossIncomes = Array.from(
       { length: 1000 },
-      (_, i) => (i * props.inputs.annualGrossSalaryRange) / 1000
+      (_, i) => (i * props.inputs.annualGrossIncomeRange) / 1000
     );
 
-    const taxData = targetAnnualGrossIncomes.map((targetAnnualGrossIncome) => {
+    const taxData = grossIncomes.map((grossIncome) => {
       const { annualGrossIncome, taxAllowance, incomeTax, employeeNI, employerNI, pensionPot, studentLoanRepayments, childBenefits, ...rest } =
         calculateTaxes({
           ...props.inputs,
-          annualGrossSalary: (targetAnnualGrossIncome - props.inputs.annualGrossBonus)
+          annualGrossBonus: 0,
+          annualGrossSalary: grossIncome,
         });
       return {
         annualGrossIncome: annualGrossIncome.total,
@@ -93,9 +94,8 @@ const TaxYearOverview = (props) => {
           return {
             x: (setting.key === "marginalCombinedTaxRate") ? dataArray.slice(1).map(data => data.annualGrossIncome) : dataArray.map(data => data.annualGrossIncome),
             y: (setting.key === "marginalCombinedTaxRate") ? marginalCombinedTaxes : dataArray.map((data, index) => {
-              const annualGrossIncome = dataArray[index].annualGrossIncome;
               const value = isPercentage
-                ? (data[setting.key] / annualGrossIncome) * 100
+                ? (data[setting.key] / dataArray[index].annualGrossIncome) * 100
                 : data[setting.key];
               return isPercentage ? Math.max(0, Math.min(100, value)) : value;
             }),

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -21,8 +21,9 @@ const requiredPositiveNumber = yup.number("Must be a number.")
     .required("Field required.");
 
 const schema = yup.object().shape({
-    grossIncome: requiredPositiveNumber,
-    salaryRange: requiredPositiveNumber,
+    annualGrossSalary: requiredPositiveNumber,
+    annualGrossBonus: requiredPositiveNumber,
+    annualGrossSalaryRange: requiredPositiveNumber,
     pensionContributions: yup.object().shape({
         autoEnrolment: requiredPositiveNumber
             .max(30, "Must be less than or equal to 30."),
@@ -34,8 +35,9 @@ const schema = yup.object().shape({
 export const defaultInputs = {
     taxYear: '2023/24',
     studentLoan: [],
-    grossIncome: 0,
-    salaryRange: 150000,
+    annualGrossSalary: 0,
+    annualGrossBonus: 0,
+    annualGrossSalaryRange: 150000,
     residentInScotland: false,
     noNI: false,
     blind: false,
@@ -69,8 +71,9 @@ const UseEffectWrapper = ({ onUserInputsChange }) => {
 
     const parseValuesToFloats = (values) => {
         let parsedValues = { ...values };
-        parsedValues.grossIncome = parseFloat(parsedValues.grossIncome);
-        parsedValues.salaryRange = parseFloat(parsedValues.salaryRange);
+        parsedValues.annualGrossSalary = parseFloat(parsedValues.annualGrossSalary);
+        parsedValues.annualGrossBonus = parseFloat(parsedValues.annualGrossBonus);
+        parsedValues.annualGrossSalaryRange = parseFloat(parsedValues.annualGrossSalaryRange);
         parsedValues.pensionContributions.autoEnrolment = parseFloat(parsedValues.pensionContributions.autoEnrolment);
         parsedValues.pensionContributions.salarySacrifice = parseFloat(parsedValues.pensionContributions.salarySacrifice);
         parsedValues.pensionContributions.personal = parseFloat(parsedValues.pensionContributions.personal);
@@ -200,6 +203,34 @@ export function UserMenu({ onUserInputsChange }) {
 
                                     <Card>
                                         <Card.Body>
+                                            <Card.Title>Bonus</Card.Title>
+                                            <Form.Group as={Row} controlId="annualGrossBonus">
+                                                <Form.Label column>Annual Gross Bonus</Form.Label>
+                                                <Col>
+                                                    <InputGroup hasValidation>
+                                                        <InputGroup.Text>£</InputGroup.Text>
+                                                        <Form.Control
+                                                            type="number"
+                                                            inputMode="decimal"
+                                                            name="annualGrossBonus"
+                                                            value={values.annualGrossBonus}
+                                                            onChange={handleInputChange}
+                                                            isValid={!errors.annualGrossBonus}
+                                                            isInvalid={!!errors.annualGrossBonus}
+                                                            min={0}
+                                                            step={1000}
+                                                        />
+                                                        <Form.Control.Feedback type="invalid">
+                                                            {errors.annualGrossBonus}
+                                                        </Form.Control.Feedback>
+                                                    </InputGroup>
+                                                </Col>
+                                            </Form.Group>
+                                        </Card.Body>
+                                    </Card>
+
+                                    <Card>
+                                        <Card.Body>
                                             <Card.Title>Pension</Card.Title>
                                             <Form.Group as={Row} controlId="pensionContributions.autoEnrolment">
                                                 <Form.Label column sm={4}>Auto Enrolment</Form.Label>
@@ -313,24 +344,24 @@ export function UserMenu({ onUserInputsChange }) {
                                             </ButtonGroup>
 
                                             {values.incomeAnalysis &&
-                                                <Form.Group as={Row} controlId="grossIncome">
-                                                    <Form.Label column>Annual Gross Income</Form.Label>
+                                                <Form.Group as={Row} controlId="annualGrossSalary">
+                                                    <Form.Label column>Annual Gross Salary</Form.Label>
                                                     <Col>
                                                         <InputGroup hasValidation>
                                                             <InputGroup.Text>£</InputGroup.Text>
                                                             <Form.Control
                                                                 type="number"
                                                                 inputMode="decimal"
-                                                                name="grossIncome"
-                                                                value={values.grossIncome}
+                                                                name="annualGrossSalary"
+                                                                value={values.annualGrossSalary}
                                                                 onChange={handleInputChange}
-                                                                isValid={!errors.grossIncome}
-                                                                isInvalid={!!errors.grossIncome}
+                                                                isValid={!errors.annualGrossSalary}
+                                                                isInvalid={!!errors.annualGrossSalary}
                                                                 min={0}
                                                                 step={1000}
                                                             />
                                                             <Form.Control.Feedback type="invalid">
-                                                                {errors.grossIncome}
+                                                                {errors.annualGrossSalary}
                                                             </Form.Control.Feedback>
                                                         </InputGroup>
                                                     </Col>
@@ -338,24 +369,24 @@ export function UserMenu({ onUserInputsChange }) {
                                             }
 
                                             {!values.incomeAnalysis &&
-                                                <Form.Group as={Row} controlId="grossIncome">
-                                                    <Form.Label column>Salary range</Form.Label>
+                                                <Form.Group as={Row} controlId="annualGrossSalaryRange">
+                                                    <Form.Label column>Annual Gross Income range</Form.Label>
                                                     <Col>
                                                         <InputGroup hasValidation>
                                                             <InputGroup.Text>£</InputGroup.Text>
                                                             <Form.Control
                                                                 type="number"
                                                                 inputMode="decimal"
-                                                                name="salaryRange"
-                                                                value={values.salaryRange}
+                                                                name="annualGrossSalaryRange"
+                                                                value={values.annualGrossSalaryRange}
                                                                 onChange={handleInputChange}
-                                                                isValid={!errors.salaryRange}
-                                                                isInvalid={!!errors.salaryRange}
+                                                                isValid={!errors.annualGrossSalaryRange}
+                                                                isInvalid={!!errors.annualGrossSalaryRange}
                                                                 min={10000}
                                                                 step={10000}
                                                             />
                                                             <Form.Control.Feedback type="invalid">
-                                                                {errors.salaryRange}
+                                                                {errors.annualGrossSalaryRange}
                                                             </Form.Control.Feedback>
                                                         </InputGroup>
                                                     </Col>

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -23,7 +23,7 @@ const requiredPositiveNumber = yup.number("Must be a number.")
 const schema = yup.object().shape({
     annualGrossSalary: requiredPositiveNumber,
     annualGrossBonus: requiredPositiveNumber,
-    annualGrossSalaryRange: requiredPositiveNumber,
+    annualGrossIncomeRange: requiredPositiveNumber,
     pensionContributions: yup.object().shape({
         autoEnrolment: requiredPositiveNumber
             .max(30, "Must be less than or equal to 30."),
@@ -37,7 +37,7 @@ export const defaultInputs = {
     studentLoan: [],
     annualGrossSalary: 0,
     annualGrossBonus: 0,
-    annualGrossSalaryRange: 150000,
+    annualGrossIncomeRange: 150000,
     residentInScotland: false,
     noNI: false,
     blind: false,
@@ -73,7 +73,7 @@ const UseEffectWrapper = ({ onUserInputsChange }) => {
         let parsedValues = { ...values };
         parsedValues.annualGrossSalary = parseFloat(parsedValues.annualGrossSalary);
         parsedValues.annualGrossBonus = parseFloat(parsedValues.annualGrossBonus);
-        parsedValues.annualGrossSalaryRange = parseFloat(parsedValues.annualGrossSalaryRange);
+        parsedValues.annualGrossIncomeRange = parseFloat(parsedValues.annualGrossIncomeRange);
         parsedValues.pensionContributions.autoEnrolment = parseFloat(parsedValues.pensionContributions.autoEnrolment);
         parsedValues.pensionContributions.salarySacrifice = parseFloat(parsedValues.pensionContributions.salarySacrifice);
         parsedValues.pensionContributions.personal = parseFloat(parsedValues.pensionContributions.personal);
@@ -203,34 +203,6 @@ export function UserMenu({ onUserInputsChange }) {
 
                                     <Card>
                                         <Card.Body>
-                                            <Card.Title>Bonus</Card.Title>
-                                            <Form.Group as={Row} controlId="annualGrossBonus">
-                                                <Form.Label column>Annual Gross Bonus</Form.Label>
-                                                <Col>
-                                                    <InputGroup hasValidation>
-                                                        <InputGroup.Text>£</InputGroup.Text>
-                                                        <Form.Control
-                                                            type="number"
-                                                            inputMode="decimal"
-                                                            name="annualGrossBonus"
-                                                            value={values.annualGrossBonus}
-                                                            onChange={handleInputChange}
-                                                            isValid={!errors.annualGrossBonus}
-                                                            isInvalid={!!errors.annualGrossBonus}
-                                                            min={0}
-                                                            step={1000}
-                                                        />
-                                                        <Form.Control.Feedback type="invalid">
-                                                            {errors.annualGrossBonus}
-                                                        </Form.Control.Feedback>
-                                                    </InputGroup>
-                                                </Col>
-                                            </Form.Group>
-                                        </Card.Body>
-                                    </Card>
-
-                                    <Card>
-                                        <Card.Body>
                                             <Card.Title>Pension</Card.Title>
                                             <Form.Group as={Row} controlId="pensionContributions.autoEnrolment">
                                                 <Form.Label column sm={4}>Auto Enrolment</Form.Label>
@@ -344,32 +316,57 @@ export function UserMenu({ onUserInputsChange }) {
                                             </ButtonGroup>
 
                                             {values.incomeAnalysis &&
-                                                <Form.Group as={Row} controlId="annualGrossSalary">
-                                                    <Form.Label column>Annual Gross Salary</Form.Label>
-                                                    <Col>
-                                                        <InputGroup hasValidation>
-                                                            <InputGroup.Text>£</InputGroup.Text>
-                                                            <Form.Control
-                                                                type="number"
-                                                                inputMode="decimal"
-                                                                name="annualGrossSalary"
-                                                                value={values.annualGrossSalary}
-                                                                onChange={handleInputChange}
-                                                                isValid={!errors.annualGrossSalary}
-                                                                isInvalid={!!errors.annualGrossSalary}
-                                                                min={0}
-                                                                step={1000}
-                                                            />
-                                                            <Form.Control.Feedback type="invalid">
-                                                                {errors.annualGrossSalary}
-                                                            </Form.Control.Feedback>
-                                                        </InputGroup>
-                                                    </Col>
-                                                </Form.Group>
+                                                <>
+                                                    <Form.Group as={Row} controlId="annualGrossSalary">
+                                                        <Form.Label column>Annual Gross Salary</Form.Label>
+                                                        <Col>
+                                                            <InputGroup hasValidation>
+                                                                <InputGroup.Text>£</InputGroup.Text>
+                                                                <Form.Control
+                                                                    type="number"
+                                                                    inputMode="decimal"
+                                                                    name="annualGrossSalary"
+                                                                    value={values.annualGrossSalary}
+                                                                    onChange={handleInputChange}
+                                                                    isValid={!errors.annualGrossSalary}
+                                                                    isInvalid={!!errors.annualGrossSalary}
+                                                                    min={0}
+                                                                    step={1000}
+                                                                />
+                                                                <Form.Control.Feedback type="invalid">
+                                                                    {errors.annualGrossSalary}
+                                                                </Form.Control.Feedback>
+                                                            </InputGroup>
+                                                        </Col>
+                                                    </Form.Group>
+
+                                                    <Form.Group as={Row} controlId="annualGrossBonus">
+                                                        <Form.Label column>Annual Gross Bonus</Form.Label>
+                                                        <Col>
+                                                            <InputGroup hasValidation>
+                                                                <InputGroup.Text>£</InputGroup.Text>
+                                                                <Form.Control
+                                                                    type="number"
+                                                                    inputMode="decimal"
+                                                                    name="annualGrossBonus"
+                                                                    value={values.annualGrossBonus}
+                                                                    onChange={handleInputChange}
+                                                                    isValid={!errors.annualGrossBonus}
+                                                                    isInvalid={!!errors.annualGrossBonus}
+                                                                    min={0}
+                                                                    step={1000}
+                                                                />
+                                                                <Form.Control.Feedback type="invalid">
+                                                                    {errors.annualGrossBonus}
+                                                                </Form.Control.Feedback>
+                                                            </InputGroup>
+                                                        </Col>
+                                                    </Form.Group>
+                                                </>
                                             }
 
                                             {!values.incomeAnalysis &&
-                                                <Form.Group as={Row} controlId="annualGrossSalaryRange">
+                                                <Form.Group as={Row} controlId="annualGrossIncomeRange">
                                                     <Form.Label column>Annual Gross Income range</Form.Label>
                                                     <Col>
                                                         <InputGroup hasValidation>
@@ -377,16 +374,16 @@ export function UserMenu({ onUserInputsChange }) {
                                                             <Form.Control
                                                                 type="number"
                                                                 inputMode="decimal"
-                                                                name="annualGrossSalaryRange"
-                                                                value={values.annualGrossSalaryRange}
+                                                                name="annualGrossIncomeRange"
+                                                                value={values.annualGrossIncomeRange}
                                                                 onChange={handleInputChange}
-                                                                isValid={!errors.annualGrossSalaryRange}
-                                                                isInvalid={!!errors.annualGrossSalaryRange}
+                                                                isValid={!errors.annualGrossIncomeRange}
+                                                                isInvalid={!!errors.annualGrossIncomeRange}
                                                                 min={10000}
                                                                 step={10000}
                                                             />
                                                             <Form.Control.Feedback type="invalid">
-                                                                {errors.annualGrossSalaryRange}
+                                                                {errors.annualGrossIncomeRange}
                                                             </Form.Control.Feedback>
                                                         </InputGroup>
                                                     </Col>


### PR DESCRIPTION
I just realised I've been calculating multiple student loans incorrectly, so this is a hotfix to get a desired behaviour:
- postgraduate loans are repaid on top of any other loans
- if a single loan is selected, repayments are calculated normally
- if more than one non-postgraduate loan is selected, the repayments stay the same as with one loan, but they are split between the two loans based on their thresholds.