### PR TITLE
Add period toggle to Tax Breakdown card

### DIFF
--- a/docs/plans/2026-03-08-period-breakdown-design.md
+++ b/docs/plans/2026-03-08-period-breakdown-design.md
@@ -1,0 +1,31 @@
+# Period Breakdown Toggle Design
+
+**Issue:** #26 — Add a monthly, weekly, and daily breakdown
+
+**Goal:** Add a toggle to the Tax Breakdown card that lets users view all figures as annual, monthly, weekly, or daily amounts.
+
+## UI
+
+A React-Bootstrap `ButtonGroup` with 4 small outline buttons (`Annual | Monthly | Weekly | Daily`) placed in the `Card.Title` row, right-aligned next to "Tax breakdown". Default: Annual.
+
+## Logic
+
+Pure display-only — no calculation changes. A single divisor applied to every displayed value:
+- Annual: ÷ 1
+- Monthly: ÷ 12
+- Weekly: ÷ 52
+- Daily: ÷ 365
+
+A `useState<'annual' | 'monthly' | 'weekly' | 'daily'>` in TaxBreakdown, defaulting to `'annual'`. The `renderSingleValue` and `renderBreakDown` helpers divide values by the divisor before formatting.
+
+## What Doesn't Change
+
+- `calculateTaxes()` — still returns annual figures only
+- Types — no changes
+- Other components — only TaxBreakdown is affected
+
+## Testing
+
+- Toggle renders with 4 buttons
+- Clicking "Monthly" divides displayed values by 12
+- "Annual" shows original values

--- a/docs/plans/2026-03-08-period-breakdown.md
+++ b/docs/plans/2026-03-08-period-breakdown.md
@@ -1,0 +1,215 @@
+# Period Breakdown Toggle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a toggle to the Tax Breakdown card so users can view figures as annual, monthly, weekly, or daily amounts.
+
+**Architecture:** Add a `useState` for the selected period in TaxBreakdown.tsx. A divisor map converts the period to a number (1/12/52/365). The existing `renderSingleValue` and `renderBreakDown` helpers divide values before formatting. A React-Bootstrap `ButtonGroup` in the card title lets users switch periods. No calculation or type changes needed.
+
+**Tech Stack:** React, TypeScript, React-Bootstrap (ButtonGroup, Button), Vitest, @testing-library/react
+
+---
+
+### Task 1: Add period toggle UI and state
+
+**Files:**
+- Modify: `src/components/IncomeAnalysis/TaxBreakdown.tsx`
+
+**Step 1: Add the period state and divisor map**
+
+At the top of the `TaxBreakdown` component (after line 15), add:
+
+```typescript
+  const [period, setPeriod] = useState<'annual' | 'monthly' | 'weekly' | 'daily'>('annual');
+
+  const divisors = { annual: 1, monthly: 12, weekly: 52, daily: 365 };
+  const divisor = divisors[period];
+```
+
+Add `useState` to the React import on line 2 (it already imports `useMemo`, so add `useState` next to it).
+
+Add `ButtonGroup, Button` to the react-bootstrap import on line 4.
+
+**Step 2: Update `renderSingleValue` to apply the divisor**
+
+Change the value display from:
+
+```typescript
+  function renderSingleValue(name: ReactNode, value: number) {
+    return (
+      <tr>
+        <td>{name}</td>
+        <td className="text-end">
+          {formatCurrencyPrecise(value)}
+        </td>
+      </tr>
+    )
+  }
+```
+
+To:
+
+```typescript
+  function renderSingleValue(name: ReactNode, value: number) {
+    return (
+      <tr>
+        <td>{name}</td>
+        <td className="text-end">
+          {formatCurrencyPrecise(value / divisor)}
+        </td>
+      </tr>
+    )
+  }
+```
+
+**Step 3: Update `renderBreakDown` to apply the divisor**
+
+In `renderBreakDown`, change the breakdown row amount from:
+
+```typescript
+            <td className="text-end small" style={{ paddingRight: "2em" }}>{formatCurrencyPrecise(tax.amount)}</td>
+```
+
+To:
+
+```typescript
+            <td className="text-end small" style={{ paddingRight: "2em" }}>{formatCurrencyPrecise(tax.amount / divisor)}</td>
+```
+
+Note: `renderBreakDown` calls `renderSingleValue` for the total, which already divides. Only the breakdown sub-rows need this change.
+
+**Step 4: Update the bold totals in the table headers**
+
+The "Total you pay" and "Total you keep" header rows format values directly. Update both:
+
+Line 64 (combinedTaxes):
+```typescript
+                {formatCurrencyPrecise(results.combinedTaxes / divisor)}
+```
+
+Line 81 (yourMoney):
+```typescript
+                {formatCurrencyPrecise(results.yourMoney / divisor)}
+```
+
+**Step 5: Add the ButtonGroup to the Card.Title**
+
+Replace the Card.Title block (lines 46-48):
+
+```tsx
+        <Card.Title>
+          Tax breakdown
+        </Card.Title>
+```
+
+With:
+
+```tsx
+        <Card.Title className="d-flex justify-content-between align-items-center">
+          Tax breakdown
+          <ButtonGroup size="sm">
+            {(['annual', 'monthly', 'weekly', 'daily'] as const).map((p) => (
+              <Button
+                key={p}
+                variant={period === p ? 'primary' : 'outline-primary'}
+                onClick={() => setPeriod(p)}
+              >
+                {p.charAt(0).toUpperCase() + p.slice(1)}
+              </Button>
+            ))}
+          </ButtonGroup>
+        </Card.Title>
+```
+
+**Step 6: Run the app and verify visually**
+
+Run: `npx vite --open`
+Expected: Tax breakdown card shows 4 buttons. Clicking "Monthly" divides all values by 12.
+
+**Step 7: Commit**
+
+```bash
+git add src/components/IncomeAnalysis/TaxBreakdown.tsx
+git commit -m "feat: add period toggle to Tax Breakdown card (#26)"
+```
+
+---
+
+### Task 2: Add tests for the period toggle
+
+**Files:**
+- Create: `src/components/IncomeAnalysis/TaxBreakdown.test.tsx`
+
+**Step 1: Write the tests**
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import TaxBreakdown from "./TaxBreakdown";
+import type { TaxInputs } from "../../types/tax";
+
+const testInputs: TaxInputs = {
+  taxYear: '2024/25',
+  studentLoan: [],
+  annualGrossSalary: 52000,
+  annualGrossBonus: 0,
+  annualGrossIncomeRange: 150000,
+  residentInScotland: false,
+  noNI: false,
+  blind: false,
+  childBenefits: { mode: 'off', numberOfChildren: 1 },
+  pensionContributions: { autoEnrolment: 0, salarySacrifice: 0, personal: 0 },
+  autoEnrolmentAsSalarySacrifice: true,
+  taxReliefAtSource: true,
+  incomeAnalysis: false,
+  pensionEnabled: false,
+  studentLoanEnabled: false,
+};
+
+describe("TaxBreakdown", () => {
+  it("renders period toggle with 4 buttons", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    expect(screen.getByRole("button", { name: "Annual" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Monthly" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Weekly" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Daily" })).toBeDefined();
+  });
+
+  it("defaults to annual view", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    // £52,000 annual gross income should appear
+    expect(screen.getByText("£52,000.00")).toBeDefined();
+  });
+
+  it("switches to monthly view when Monthly is clicked", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    fireEvent.click(screen.getByRole("button", { name: "Monthly" }));
+    // £52,000 / 12 = £4,333.33
+    expect(screen.getByText("£4,333.33")).toBeDefined();
+  });
+
+  it("switches back to annual view", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    fireEvent.click(screen.getByRole("button", { name: "Monthly" }));
+    fireEvent.click(screen.getByRole("button", { name: "Annual" }));
+    expect(screen.getByText("£52,000.00")).toBeDefined();
+  });
+});
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/IncomeAnalysis/TaxBreakdown.test.tsx`
+Expected: ALL PASS (4 tests)
+
+**Step 3: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: ALL PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/components/IncomeAnalysis/TaxBreakdown.test.tsx
+git commit -m "test: add tests for period toggle in TaxBreakdown (#26)"
+```

--- a/src/components/IncomeAnalysis/TaxBreakdown.test.tsx
+++ b/src/components/IncomeAnalysis/TaxBreakdown.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import TaxBreakdown from "./TaxBreakdown";
+import type { TaxInputs } from "../../types/tax";
+
+const testInputs: TaxInputs = {
+  taxYear: '2024/25',
+  studentLoan: [],
+  annualGrossSalary: 52000,
+  annualGrossBonus: 0,
+  annualGrossIncomeRange: 150000,
+  residentInScotland: false,
+  noNI: false,
+  blind: false,
+  childBenefits: { mode: 'off', numberOfChildren: 1 },
+  pensionContributions: { autoEnrolment: 0, salarySacrifice: 0, personal: 0 },
+  autoEnrolmentAsSalarySacrifice: true,
+  taxReliefAtSource: true,
+  incomeAnalysis: false,
+  pensionEnabled: false,
+  studentLoanEnabled: false,
+};
+
+describe("TaxBreakdown", () => {
+  it("renders period toggle with 4 buttons", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    expect(screen.getByRole("button", { name: "Annual" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Monthly" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Weekly" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Daily" })).toBeDefined();
+  });
+
+  it("defaults to annual view", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    // £52,000 annual gross income should appear (may appear in multiple cells)
+    expect(screen.getAllByText("£52,000.00").length).toBeGreaterThan(0);
+  });
+
+  it("switches to monthly view when Monthly is clicked", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    fireEvent.click(screen.getByRole("button", { name: "Monthly" }));
+    // £52,000 / 12 = £4,333.33
+    expect(screen.getAllByText("£4,333.33").length).toBeGreaterThan(0);
+  });
+
+  it("switches back to annual view", () => {
+    render(<TaxBreakdown inputs={testInputs} />);
+    fireEvent.click(screen.getByRole("button", { name: "Monthly" }));
+    fireEvent.click(screen.getByRole("button", { name: "Annual" }));
+    expect(screen.getAllByText("£52,000.00").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/IncomeAnalysis/TaxBreakdown.tsx
+++ b/src/components/IncomeAnalysis/TaxBreakdown.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { calculateTaxes } from "../../utils/TaxCalc";
-import { Table, Card } from "react-bootstrap";
+import { Table, Card, ButtonGroup, Button } from "react-bootstrap";
 import { formatCurrencyPrecise } from "../../utils/chartUtils";
 import type { TaxInputs, CalculationResult } from "../../types/tax";
 import InfoPopover from '../InfoPopover';
@@ -13,13 +13,16 @@ interface TaxBreakdownProps {
 
 const TaxBreakdown = (props: TaxBreakdownProps) => {
   const results = useMemo(() => calculateTaxes(props.inputs), [props.inputs]);
+  const [period, setPeriod] = useState<'annual' | 'monthly' | 'weekly' | 'daily'>('annual');
+  const divisors = { annual: 1, monthly: 12, weekly: 52, daily: 365 };
+  const divisor = divisors[period];
 
   function renderSingleValue(name: ReactNode, value: number) {
     return (
       <tr>
         <td>{name}</td>
         <td className="text-end">
-          {formatCurrencyPrecise(value)}
+          {formatCurrencyPrecise(value / divisor)}
         </td>
       </tr>
     )
@@ -33,7 +36,7 @@ const TaxBreakdown = (props: TaxBreakdownProps) => {
           <tr key={`it-${i}`}>
             <td className="small" style={{ paddingLeft: "2em" }}>{`${typeof tax.rate === 'string' ? tax.rate : (tax.rate * 100).toFixed(2) + "%"
               }`}</td>
-            <td className="text-end small" style={{ paddingRight: "2em" }}>{formatCurrencyPrecise(tax.amount)}</td>
+            <td className="text-end small" style={{ paddingRight: "2em" }}>{formatCurrencyPrecise(tax.amount / divisor)}</td>
           </tr>
         ))}
       </>
@@ -43,8 +46,19 @@ const TaxBreakdown = (props: TaxBreakdownProps) => {
   return (
     <Card>
       <Card.Body>
-        <Card.Title>
+        <Card.Title className="d-flex justify-content-between align-items-center">
           Tax breakdown
+          <ButtonGroup size="sm">
+            {(['annual', 'monthly', 'weekly', 'daily'] as const).map((p) => (
+              <Button
+                key={p}
+                variant={period === p ? 'primary' : 'outline-primary'}
+                onClick={() => setPeriod(p)}
+              >
+                {p.charAt(0).toUpperCase() + p.slice(1)}
+              </Button>
+            ))}
+          </ButtonGroup>
         </Card.Title>
 
         <Table size="sm">
@@ -61,7 +75,7 @@ const TaxBreakdown = (props: TaxBreakdownProps) => {
             <tr>
               <th>Total you pay <InfoPopover {...explanations.result_combinedTaxes} /></th>
               <td style={{ fontWeight: "bold" }} className="text-end">
-                {formatCurrencyPrecise(results.combinedTaxes)}
+                {formatCurrencyPrecise(results.combinedTaxes / divisor)}
               </td>
             </tr>
           </thead>
@@ -78,7 +92,7 @@ const TaxBreakdown = (props: TaxBreakdownProps) => {
             <tr>
               <th>Total you keep <InfoPopover {...explanations.result_yourMoney} /></th>
               <td style={{ fontWeight: "bold" }} className="text-end">
-                {formatCurrencyPrecise(results.yourMoney)}
+                {formatCurrencyPrecise(results.yourMoney / divisor)}
               </td>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary

Closes #26

- Adds a `ButtonGroup` toggle (Annual | Monthly | Weekly | Daily) to the Tax Breakdown card header
- All displayed values (totals, sub-breakdowns, summary rows) are divided by the selected period's divisor (1/12/52/365)
- Defaults to Annual view — pure display change, no calculation logic modified

## Test plan

- [x] 4 new component tests: renders all buttons, defaults to annual, switches to monthly (£52,000 → £4,333.33), switches back
- [x] All 61 tests pass
- [x] Manual: verify toggle visually switches all values in all three tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)