### PR TITLE
Add disclaimer for non-annual period views

### DIFF
--- a/src/components/IncomeAnalysis/TaxBreakdown.tsx
+++ b/src/components/IncomeAnalysis/TaxBreakdown.tsx
@@ -102,6 +102,12 @@ const TaxBreakdown = (props: TaxBreakdownProps) => {
             {results.childBenefits.total > 0 && renderBreakDown(<>Child Benefits <InfoPopover {...explanations.result_childBenefits} /></>, results.childBenefits)}
           </tbody>
         </Table>
+
+        {period !== 'annual' && (
+          <p className="text-muted small mb-0">
+            Figures are annual calculations divided by period. Actual payslip amounts may differ slightly due to per-period NI and Student Loan thresholds.
+          </p>
+        )}
       </Card.Body>
     </Card>
   );


### PR DESCRIPTION
## Summary

Follow-up to #26 (PR #76). When users view figures in monthly/weekly/daily mode, a small disclaimer now appears:

> Figures are annual calculations divided by period. Actual payslip amounts may differ slightly due to per-period NI and Student Loan thresholds.

This is hidden in annual view (the default) since it's not relevant.

## Why

UK National Insurance and Student Loan repayments are legally calculated per pay period with period-specific thresholds that don't perfectly divide from annual amounts. The toggle shows annual figures ÷ N, which is useful for budgeting but won't exactly match payslip amounts.

## Test plan

- [x] All 114 tests pass
- [ ] Manual: switch to Monthly/Weekly/Daily — disclaimer appears. Switch back to Annual — disclaimer hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)