### PR TITLE
Fix leading zero, view toggle reset, and infinite render loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Container, Row, Col, ButtonGroup, Button } from "react-bootstrap";
 import { defaultInputs, UserMenu } from "./components/UserMenu";
 import TaxYearOverview from "./components/TaxYearOverview";
 import IncomeAnalysis from "./components/IncomeAnalysis";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import type { TaxInputs } from "./types/tax";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 const getInitialTheme = () => {
@@ -28,13 +29,17 @@ function App() {
     setTheme(theme === "light" ? "dark" : "light");
   }
 
+  const handleUserInputsChange = useCallback((inputs: TaxInputs) => {
+    setUserInputs(prev => ({ ...inputs, incomeAnalysis: prev.incomeAnalysis }));
+  }, []);
+
   return (
     <Container fluid className="d-flex flex-column min-vh-100 p-0">
       <Container className="page-content p-0">
         <Row>
           <Col xs={12} lg={6}>
             <Header theme={theme} toggleTheme={toggleTheme} />
-            <UserMenu onUserInputsChange={(inputs) => setUserInputs(prev => ({ ...inputs, incomeAnalysis: prev.incomeAnalysis }))} />
+            <UserMenu onUserInputsChange={handleUserInputsChange} />
           </Col>
           <Col xs={12} lg={6} className="pt-3">
             <ButtonGroup className="mb-3">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         <Row>
           <Col xs={12} lg={6}>
             <Header theme={theme} toggleTheme={toggleTheme} />
-            <UserMenu onUserInputsChange={setUserInputs} />
+            <UserMenu onUserInputsChange={(inputs) => setUserInputs(prev => ({ ...inputs, incomeAnalysis: prev.incomeAnalysis }))} />
           </Col>
           <Col xs={12} lg={6} className="pt-3">
             <ButtonGroup className="mb-3">

--- a/src/components/TaxYearOverview.tsx
+++ b/src/components/TaxYearOverview.tsx
@@ -178,8 +178,8 @@ const TaxYearOverview = (props: TaxYearOverviewProps) => {
             <Form.Control
               type="number"
               inputMode="decimal"
-              value={incomeRange}
-              onChange={(e) => setIncomeRange(Number(e.target.value) || 0)}
+              value={incomeRange || ''}
+              onChange={(e) => setIncomeRange(Number(e.target.value))}
               min={10000}
               step={10000}
             />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/setupTests.tsx',
     css: true,
+    exclude: ['**/node_modules/**', '.worktrees/**'],
   },
 });


### PR DESCRIPTION
## Summary
- **Leading zero in income range input**: Typing in the income range field would prepend zeros (e.g. "020000"). Fixed with `value={incomeRange || ''}` pattern.
- **View toggle reset on input change**: Changing any left-side input reset the view to "My Taxes". Caused by Formik's UseEffectWrapper overwriting `incomeAnalysis` state. Fixed by preserving `incomeAnalysis` from previous state.
- **Infinite render loop**: The inline arrow function for `onUserInputsChange` created a new reference every render, causing UseEffectWrapper's `useEffect` to fire infinitely. Wrapped with `useCallback` to stabilize the reference.
- **Worktree test exclusion**: Added `.worktrees/**` to vitest exclude to prevent duplicate test runs.

## Test plan
- [x] All 62 tests pass (App.test.tsx was previously hanging indefinitely)
- [x] Verify income range input accepts typed values without leading zeros
- [x] Verify switching to Income Explorer stays when changing left-side inputs
- [x] Verify My Taxes / Income Explorer toggle works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)